### PR TITLE
Slim down the deps and packaging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  target-branch: "master"
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "06:00"
+    timezone: America/Los_Angeles
+  open-pull-requests-limit: 10
+  labels:
+  - "Type: Chore"

--- a/train-rest.gemspec
+++ b/train-rest.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
 
   spec.files = %w{
-    README.md train-rest.gemspec Gemfile
+    train-rest.gemspec
   } + Dir.glob(
     "lib/**/*", File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }

--- a/train-rest.gemspec
+++ b/train-rest.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   ).reject { |f| File.directory?(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "train", "~> 3.0"
+  spec.add_dependency "train-core", "~> 3.0"
   spec.add_dependency "rest-client", "~> 2.1"
 
   spec.add_development_dependency "bump", "~> 0.9"

--- a/train-rest.gemspec
+++ b/train-rest.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rest-client", "~> 2.1"
 
   spec.add_development_dependency "bump", "~> 0.9"
-  spec.add_development_dependency "chefstyle", "~> 0.14"
+  spec.add_development_dependency "chefstyle", "~> 2.2"
   spec.add_development_dependency "guard", "~> 2.16"
   spec.add_development_dependency "mdl", "~> 0.9"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/train-rest.gemspec
+++ b/train-rest.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["theinen@tecracer.de"]
   spec.summary       = "Train transport for REST"
   spec.description   = "Provides a transport to communicate easily with RESTful APIs."
-  spec.homepage      = "https://github.com/sgre-chef/train-rest"
+  spec.homepage      = "https://github.com/tecracer-chef/train-rest"
   spec.license       = "Apache-2.0"
 
   spec.files = %w{


### PR DESCRIPTION
- Remove a few items from the gem
- Dep on train-core vs. train which has docker-api and all the cloud SDKs
- Use the latest Chefstyle
- Setup Dependabot to keep the deps up to date